### PR TITLE
QOrganizer: Fix handling of item IDs

### DIFF
--- a/organizer/qorganizer-eds-engine.h
+++ b/organizer/qorganizer-eds-engine.h
@@ -122,13 +122,22 @@ public:
     virtual QList<QtOrganizer::QOrganizerItemDetail::DetailType> supportedItemDetails(QtOrganizer::QOrganizerItemType::ItemType itemType) const;
     virtual QList<QtOrganizer::QOrganizerItemType::ItemType> supportedItemTypes() const;
 
+    /* Map between EDS items (source + uid) and QtOrganizer items
+     * (QOrganizerCollectionId + QOrganizerItemId):
+     */
+    static QtOrganizer::QOrganizerItemId
+        idFromEds(const QtOrganizer::QOrganizerCollectionId &collectionId,
+                  const gchar *uid);
+    static QByteArray idToEds(const QtOrganizer::QOrganizerItemId &itemId,
+                              QByteArray *sourceId = nullptr);
+
     // debug
     int runningRequestCount() const;
 
 protected Q_SLOTS:
-    void onSourceAdded(const QString &collectionId);
-    void onSourceRemoved(const QString &collectionId);
-    void onSourceUpdated(const QString &collectionId);
+    void onSourceAdded(const QByteArray &sourceId);
+    void onSourceRemoved(const QByteArray &sourceId);
+    void onSourceUpdated(const QByteArray &sourceId);
     void onViewChanged(QtOrganizer::QOrganizerItemChangeSet *change);
 
 protected:
@@ -139,8 +148,8 @@ private:
     QOrganizerEDSEngineData *d;
     QMap<QtOrganizer::QOrganizerAbstractRequest*, RequestData*> m_runningRequests;
 
-    QList<QtOrganizer::QOrganizerItem> parseEvents(const QString &collectionId, GSList *events, bool isIcalEvents, QList<QtOrganizer::QOrganizerItemDetail::DetailType> detailsHint);
-    void parseEventsAsync(const QMap<QString, GSList *> &events,
+    QList<QtOrganizer::QOrganizerItem> parseEvents(const QByteArray &sourceId, GSList *events, bool isIcalEvents, QList<QtOrganizer::QOrganizerItemDetail::DetailType> detailsHint);
+    void parseEventsAsync(const QMap<QByteArray, GSList *> &events,
                           bool isIcalEvents,
                           QList<QtOrganizer::QOrganizerItemDetail::DetailType> detailsHint,
                           QObject *source,
@@ -210,7 +219,7 @@ private:
     static ECalComponent *parseEventItem(ECalClient *client, const QtOrganizer::QOrganizerItem &item);
     static ECalComponent *parseTodoItem(ECalClient *client, const QtOrganizer::QOrganizerItem &item);
     static ECalComponent *parseJournalItem(ECalClient *client, const QtOrganizer::QOrganizerItem &item);
-    static QString toComponentId(const QString &itemId, QString *rid);
+    static QByteArray toComponentId(const QByteArray &itemId, QByteArray *rid);
     static ECalComponentId *ecalComponentId(const QtOrganizer::QOrganizerItemId &itemId);
 
     // glib callback

--- a/organizer/qorganizer-eds-enginedata.cpp
+++ b/organizer/qorganizer-eds-enginedata.cpp
@@ -42,21 +42,22 @@ QOrganizerEDSEngineData::~QOrganizerEDSEngineData()
     }
 }
 
-ViewWatcher* QOrganizerEDSEngineData::watch(const QString &collectionId)
+ViewWatcher* QOrganizerEDSEngineData::watch(const QOrganizerCollectionId &collectionId)
 {
-    ViewWatcher *vw = m_viewWatchers[collectionId];
+    QByteArray sourceId = collectionId.localId();
+    ViewWatcher *vw = m_viewWatchers[sourceId];
     if (!vw) {
-        EClient *client = m_sourceRegistry->client(collectionId);
+        EClient *client = m_sourceRegistry->client(sourceId);
         vw = new ViewWatcher(collectionId, this, client);
-        m_viewWatchers.insert(collectionId, vw);
+        m_viewWatchers.insert(sourceId, vw);
         g_object_unref(client);
     }
     return vw;
 }
 
-void QOrganizerEDSEngineData::unWatch(const QString &collectionId)
+void QOrganizerEDSEngineData::unWatch(const QByteArray &sourceId)
 {
-    ViewWatcher *viewW = m_viewWatchers.take(collectionId);
+    ViewWatcher *viewW = m_viewWatchers.take(sourceId);
     if (viewW) {
         delete viewW;
     }

--- a/organizer/qorganizer-eds-enginedata.h
+++ b/organizer/qorganizer-eds-enginedata.h
@@ -46,15 +46,15 @@ public:
         }
     }
 
-    ViewWatcher* watch(const QString &collectionId);
-    void unWatch(const QString &collectionId);
+    ViewWatcher* watch(const QtOrganizer::QOrganizerCollectionId &collectionId);
+    void unWatch(const QByteArray &sourceId);
 
     QAtomicInt m_refCount;
     SourceRegistry *m_sourceRegistry;
     QSet<QtOrganizer::QOrganizerManagerEngine*> m_sharedEngines;
 
 private:
-    QMap<QString, ViewWatcher*> m_viewWatchers;
+    QMap<QByteArray, ViewWatcher*> m_viewWatchers;
 
 };
 

--- a/organizer/qorganizer-eds-fetchbyidrequestdata.cpp
+++ b/organizer/qorganizer-eds-fetchbyidrequestdata.cpp
@@ -34,29 +34,31 @@ FetchByIdRequestData::~FetchByIdRequestData()
 {
 }
 
-QString FetchByIdRequestData::nextId()
+QOrganizerItemId FetchByIdRequestData::nextId()
 {
-    QString id;
+    QOrganizerItemId id;
     QList<QOrganizerItemId> ids = request<QOrganizerItemFetchByIdRequest>()->ids();
     m_current++;
     if (m_current < ids.count()) {
-        id = ids[m_current].toString();
+        id = ids[m_current];
     }
     return id;
 }
 
-QString FetchByIdRequestData::currentId() const
+QOrganizerItemId FetchByIdRequestData::currentId() const
 {
-    return request<QOrganizerItemFetchByIdRequest>()->ids()[m_current].toString();
+    return request<QOrganizerItemFetchByIdRequest>()->ids()[m_current];
 }
 
-QString FetchByIdRequestData::currentCollectionId() const
+QByteArray FetchByIdRequestData::currentSourceId() const
 {
-    QString itemId = currentId();
-    if (!itemId.isEmpty()) {
-        return itemId.contains("/") ? itemId.split("/").first() : QString();
+    QOrganizerItemId itemId = currentId();
+    if (!itemId.isNull()) {
+        QByteArray sourceId;
+        QOrganizerEDSEngine::idToEds(itemId, &sourceId);
+        return sourceId;
     }
-    return QString();
+    return QByteArray();
 }
 
 bool FetchByIdRequestData::end() const

--- a/organizer/qorganizer-eds-fetchbyidrequestdata.h
+++ b/organizer/qorganizer-eds-fetchbyidrequestdata.h
@@ -29,9 +29,9 @@ public:
                          QtOrganizer::QOrganizerAbstractRequest *req);
     ~FetchByIdRequestData();
 
-    QString nextId();
-    QString currentId() const;
-    QString currentCollectionId() const;
+    QtOrganizer::QOrganizerItemId nextId();
+    QtOrganizer::QOrganizerItemId currentId() const;
+    QByteArray currentSourceId() const;
     bool end() const;
 
     void finish(QtOrganizer::QOrganizerManager::Error error = QtOrganizer::QOrganizerManager::NoError,

--- a/organizer/qorganizer-eds-fetchocurrencedata.cpp
+++ b/organizer/qorganizer-eds-fetchocurrencedata.cpp
@@ -69,8 +69,8 @@ void FetchOcurrenceData::finish(QOrganizerManager::Error error,
 
     if (m_components) {
         QOrganizerItemOccurrenceFetchRequest *req = request<QOrganizerItemOccurrenceFetchRequest>();
-        QString collectionId = req->parentItem().collectionId().toString();
-        results = parent()->parseEvents(collectionId, m_components, true,
+        QByteArray sourceId = req->parentItem().collectionId().localId();
+        results = parent()->parseEvents(sourceId, m_components, true,
                                         req->fetchHint().detailTypesHint());
         g_slist_free_full(m_components, (GDestroyNotify)icalcomponent_free);
         m_components = 0;

--- a/organizer/qorganizer-eds-fetchrequestdata.h
+++ b/organizer/qorganizer-eds-fetchrequestdata.h
@@ -28,13 +28,13 @@ class FetchRequestData : public RequestData
 {
 public:
     FetchRequestData(QOrganizerEDSEngine *engine,
-                     QStringList collections,
+                     const QByteArrayList &sourceIds,
                      QtOrganizer::QOrganizerAbstractRequest *req);
     ~FetchRequestData();
 
-    QString nextCollection();
-    QString nextParentId();
-    QString collection() const;
+    QByteArray nextSourceId();
+    QByteArray nextParentId();
+    QByteArray sourceId() const;
     time_t startDate() const;
     time_t endDate() const;
     bool hasDateInterval() const;
@@ -51,16 +51,16 @@ public:
 
 private:
     FetchRequestDataParseListener *m_parseListener;
-    QMap<QString, GSList*> m_components;
-    QStringList m_collections;
-    QSet<QString> m_currentParentIds;
-    QStringList m_deatachedIds;
-    QString m_current;
+    QMap<QByteArray, GSList*> m_components;
+    QByteArrayList m_sourceIds;
+    QSet<QByteArray> m_currentParentIds;
+    QByteArrayList m_deatachedIds;
+    QByteArray m_current;
     GSList* m_currentComponents;
     QList<QtOrganizer::QOrganizerItem> m_results;
 
-    QStringList filterCollections(const QStringList &collections) const;
-    QStringList collectionsFromFilter(const QtOrganizer::QOrganizerItemFilter &f) const;
+    QByteArrayList filterSourceIds(const QByteArrayList &collections) const;
+    QByteArrayList sourceIdsFromFilter(const QtOrganizer::QOrganizerItemFilter &f) const;
     void finishContinue(QtOrganizer::QOrganizerManager::Error error,
                         QtOrganizer::QOrganizerAbstractRequest::State state);
 

--- a/organizer/qorganizer-eds-removebyidrequestdata.h
+++ b/organizer/qorganizer-eds-removebyidrequestdata.h
@@ -29,21 +29,22 @@ public:
     RemoveByIdRequestData(QOrganizerEDSEngine *engine, QtOrganizer::QOrganizerAbstractRequest *req);
     ~RemoveByIdRequestData();
 
-    QString collectionId() const;
+    QByteArray sourceId() const;
 
     void finish(QtOrganizer::QOrganizerManager::Error error = QtOrganizer::QOrganizerManager::NoError,
                 QtOrganizer::QOrganizerAbstractRequest::State state = QtOrganizer::QOrganizerAbstractRequest::FinishedState);
 
     GSList *compIds() const;
 
-    QString next();
+    QByteArray next();
     void commit();
     virtual void cancel();
 
 private:
-    QHash<QString, QSet<QtOrganizer::QOrganizerItemId> > m_pending;
+    // Map source IDs to sets of items
+    QHash<QByteArray, QSet<QtOrganizer::QOrganizerItemId> > m_pending;
     QSet<QtOrganizer::QOrganizerItemId> m_currentIds;
-    QString m_currentCollectionId;
+    QByteArray m_currentSourceId;
 
     bool m_sessionStaterd;
     GSList *m_currentCompIds;

--- a/organizer/qorganizer-eds-removecollectionrequestdata.cpp
+++ b/organizer/qorganizer-eds-removecollectionrequestdata.cpp
@@ -56,7 +56,7 @@ void RemoveCollectionRequestData::commit(QtOrganizer::QOrganizerManager::Error e
         m_errorMap.insert(m_currentCollection, error);
     } else {
         QOrganizerCollectionId cId = m_pendingCollections.at(m_currentCollection);
-        parent()->d->m_sourceRegistry->remove(cId.toString());
+        parent()->d->m_sourceRegistry->remove(cId.localId());
     }
 
     m_currentCollection++;
@@ -77,7 +77,7 @@ ESource *RemoveCollectionRequestData::begin()
 {
     if (m_pendingCollections.count() > m_currentCollection) {
         QOrganizerCollectionId cId = m_pendingCollections.at(m_currentCollection);
-        return parent()->d->m_sourceRegistry->source(cId.toString());
+        return parent()->d->m_sourceRegistry->source(cId.localId());
     } else {
         return 0;
     }

--- a/organizer/qorganizer-eds-savecollectionrequestdata.cpp
+++ b/organizer/qorganizer-eds-savecollectionrequestdata.cpp
@@ -166,7 +166,7 @@ void SaveCollectionRequestData::parseCollections()
         if (isNew) {
             source = SourceRegistry::newSourceFromCollection(collection);
         } else {
-            source = m_parent->d->m_sourceRegistry->source(collection.id().toString());
+            source = m_parent->d->m_sourceRegistry->source(collection.id().localId());
         }
 
         QVariant callendarType = collection.extendedMetaData(COLLECTION_CALLENDAR_TYPE_METADATA);

--- a/organizer/qorganizer-eds-saverequestdata.cpp
+++ b/organizer/qorganizer-eds-saverequestdata.cpp
@@ -30,15 +30,12 @@ SaveRequestData::SaveRequestData(QOrganizerEDSEngine *engine,
                                  QtOrganizer::QOrganizerAbstractRequest *req)
     : RequestData(engine, req)
 {
-    // map items by collection
+    // map items by source
     Q_FOREACH(const QOrganizerItem &i, request<QOrganizerItemSaveRequest>()->items()) {
-        QString collectionId = i.collectionId().toString();
-        if (collectionId == QStringLiteral("qtorganizer:::"))  {
-            collectionId = QStringLiteral("");
-        }
-        QList<QOrganizerItem> li = m_items[collectionId];
+        QByteArray sourceId = i.collectionId().localId();
+        QList<QOrganizerItem> li = m_items[sourceId];
         li << i;
-        m_items.insert(collectionId, li);
+        m_items.insert(sourceId, li);
     }
 }
 
@@ -64,22 +61,22 @@ void SaveRequestData::appendResults(QList<QOrganizerItem> result)
     m_result += result;
 }
 
-QString SaveRequestData::nextCollection()
+QByteArray SaveRequestData::nextSourceId()
 {
     if (m_items.isEmpty()) {
-        m_currentCollection = QString(QString::null);
+        m_currentSourceId = QByteArray();
         m_currentItems.clear();
     } else {
-        m_currentCollection = m_items.keys().first();
-        m_currentItems = m_items.take(m_currentCollection);
+        m_currentSourceId = m_items.keys().first();
+        m_currentItems = m_items.take(m_currentSourceId);
     }
     m_workingItems.clear();
-    return m_currentCollection;
+    return m_currentSourceId;
 }
 
-QString SaveRequestData::currentCollection() const
+QByteArray SaveRequestData::currentSourceId() const
 {
-    return m_currentCollection;
+    return m_currentSourceId;
 }
 
 QList<QOrganizerItem> SaveRequestData::takeItemsToCreate()

--- a/organizer/qorganizer-eds-saverequestdata.h
+++ b/organizer/qorganizer-eds-saverequestdata.h
@@ -33,8 +33,8 @@ public:
                 QtOrganizer::QOrganizerAbstractRequest::State state = QtOrganizer::QOrganizerAbstractRequest::FinishedState);
 
 
-    QString nextCollection();
-    QString currentCollection() const;
+    QByteArray nextSourceId();
+    QByteArray currentSourceId() const;
     QList<QtOrganizer::QOrganizerItem> takeItemsToCreate();
     QList<QtOrganizer::QOrganizerItem> takeItemsToUpdate();
     bool end() const;
@@ -47,10 +47,10 @@ public:
 private:
     QList<QtOrganizer::QOrganizerItem> m_result;
     QMap<int, QtOrganizer::QOrganizerManager::Error> m_erros;
-    QMap<QString, QList<QtOrganizer::QOrganizerItem> > m_items;
+    QMap<QByteArray, QList<QtOrganizer::QOrganizerItem> > m_items;
     QList<QtOrganizer::QOrganizerItem> m_currentItems;
     QList<QtOrganizer::QOrganizerItem> m_workingItems;
-    QString m_currentCollection;
+    QByteArray m_currentSourceId;
 };
 
 #endif

--- a/organizer/qorganizer-eds-source-registry.h
+++ b/organizer/qorganizer-eds-source-registry.h
@@ -45,16 +45,16 @@ public:
     void load(const QString &managerUri);
     QtOrganizer::QOrganizerCollection defaultCollection() const;
     void setDefaultCollection(QtOrganizer::QOrganizerCollection &collection);
-    QtOrganizer::QOrganizerCollection collection(const QString &collectionId) const;
+    QtOrganizer::QOrganizerCollection collection(const QByteArray &sourceId) const;
     QList<QtOrganizer::QOrganizerCollection> collections() const;
-    QStringList collectionsIds() const;
-    ESource *source(const QString &collectionId) const;
-    QtOrganizer::QOrganizerCollectionId collectionId(const QString &cid) const;
+    QByteArrayList sourceIds() const;
+    ESource *source(const QByteArray &sourceId) const;
+    QtOrganizer::QOrganizerCollectionId collectionId(const QByteArray &sourceId) const;
     QtOrganizer::QOrganizerCollection collection(ESource *source) const;
     QtOrganizer::QOrganizerCollection insert(ESource *source);
     void remove(ESource *source);
-    void remove(const QString &collectionId);
-    EClient *client(const QString &collectionId);
+    void remove(const QByteArray &sourceId);
+    EClient *client(const QByteArray &sourceId);
     void clear();
 
     static QtOrganizer::QOrganizerCollection parseSource(const QString &managerUri,
@@ -63,18 +63,18 @@ public:
     static ESource *newSourceFromCollection(const QtOrganizer::QOrganizerCollection &collection);
 
 Q_SIGNALS:
-    void sourceAdded(const QString &collectionId);
-    void sourceRemoved(const QString &collectionId);
-    void sourceUpdated(const QString &collectionId);
+    void sourceAdded(const QByteArray &sourceId);
+    void sourceRemoved(const QByteArray &sourceId);
+    void sourceUpdated(const QByteArray &sourceId);
 
 private:
     QSettings m_settings;
     QString m_managerUri;
     ESourceRegistry *m_sourceRegistry;
     QtOrganizer::QOrganizerCollection m_defaultCollection;
-    QMap<QString, EClient*> m_clients;
-    QMap<QString, ESource*> m_sources;
-    QMap<QString, QtOrganizer::QOrganizerCollection> m_collections;
+    QMap<QByteArray, EClient*> m_clients;
+    QMap<QByteArray, ESource*> m_sources;
+    QMap<QByteArray, QtOrganizer::QOrganizerCollection> m_collections;
 
     // handler id
     int m_sourceAddedId;
@@ -84,8 +84,8 @@ private:
     int m_sourceDisabledId;
     int m_defaultSourceChangedId;
 
-    QByteArray defaultCollectionId() const;
-    QString findCollection(ESource *source) const;
+    QByteArray defaultSourceId() const;
+    QByteArray findSource(ESource *source) const;
     QtOrganizer::QOrganizerCollection registerSource(ESource *source, bool isDefault = false);
     void updateDefaultCollection(QtOrganizer::QOrganizerCollection *collection);
     static void updateCollection(QtOrganizer::QOrganizerCollection *collection,

--- a/organizer/qorganizer-eds-viewwatcher.cpp
+++ b/organizer/qorganizer-eds-viewwatcher.cpp
@@ -29,7 +29,7 @@
 
 using namespace QtOrganizer;
 
-ViewWatcher::ViewWatcher(const QString &collectionId,
+ViewWatcher::ViewWatcher(const QOrganizerCollectionId &collectionId,
                          QOrganizerEDSEngineData *data,
                          EClient *client)
     : m_collectionId(collectionId),
@@ -147,9 +147,7 @@ QList<QOrganizerItemId> ViewWatcher::parseItemIds(GSList *objects)
             qWarning() << "Fail to parse component ID";
         }
 
-        QOrganizerCollectionId collectionId =
-            QOrganizerCollectionId::fromString(m_collectionId);
-        QOrganizerItemId itemId(collectionId.managerUri(), uid);
+        QOrganizerItemId itemId = QOrganizerEDSEngine::idFromEds(m_collectionId, uid);
         result << itemId;
     }
     return result;
@@ -183,9 +181,7 @@ void ViewWatcher::onObjectsRemoved(ECalClientView *view,
 
     for (GSList *l = objects; l; l = l->next) {
         ECalComponentId *id = static_cast<ECalComponentId*>(l->data);
-        QOrganizerCollectionId collectionId =
-            QOrganizerCollectionId::fromString(self->m_collectionId);
-        QOrganizerItemId itemId(collectionId.managerUri(), id->uid);
+        QOrganizerItemId itemId = QOrganizerEDSEngine::idFromEds(self->m_collectionId, id->uid);
         self->m_changeSet.insertRemovedItem(itemId);
     }
     self->notify();

--- a/organizer/qorganizer-eds-viewwatcher.h
+++ b/organizer/qorganizer-eds-viewwatcher.h
@@ -34,7 +34,7 @@ class ViewWatcher : public QObject
 {
     Q_OBJECT
 public:
-    ViewWatcher(const QString &collectionId,
+    ViewWatcher(const QOrganizerCollectionId &collectionId,
                 QOrganizerEDSEngineData *data,
                 EClient *client);
     virtual ~ViewWatcher();
@@ -45,7 +45,7 @@ private Q_SLOTS:
     void flush();
 
 private:
-    QString m_collectionId;
+    QOrganizerCollectionId m_collectionId;
     QOrganizerEDSEngineData *m_engineData;
     GCancellable *m_cancellable;
     ECalClient *m_eClient;

--- a/tests/unittest/parseecal-test.cpp
+++ b/tests/unittest/parseecal-test.cpp
@@ -388,8 +388,8 @@ private Q_SLOTS:
 
         QList<QOrganizerItemDetail::DetailType> detailsHint;
         GSList *events = g_slist_append(events, ical);
-        QMap<QString, GSList*> eventMap;
-        eventMap.insert(engine->defaultCollection(0).id().toString(), events);
+        QMap<QByteArray, GSList*> eventMap;
+        eventMap.insert(engine->defaultCollection(0).id().localId(), events);
         engine->parseEventsAsync(eventMap, true, detailsHint, this, SLOT(onEventAsyncParsed(QList<QOrganizerItem>)));
 
         QTRY_COMPARE(m_itemsParsed.size(), 1);


### PR DESCRIPTION
This commit heavily reworks the way that item IDs are passed around.
First we add a couple of static functions to QOrganizerEdsEngine, to
translate from EDS coordinates, which consiste of a source ID and an
item ID, to QtOrganizer coordinates, which consist of a single
QOrganizerItemId (inside which we encode both athe EDS source and item
ID).

Then, we stop using a QString to store the collection ID, but either use
the proper QOrganizerCollectionId class or, wherever possible, just the
EDS source ID (which corresponds to QOrganizerCollectionId::localId()).

Fixes https://github.com/ubports/ubuntu-touch/issues/869