### PR TITLE
QOrganizer: override defaultCollectionId()

### DIFF
--- a/organizer/qorganizer-eds-engine.cpp
+++ b/organizer/qorganizer-eds-engine.cpp
@@ -692,7 +692,7 @@ void QOrganizerEDSEngine::saveItemsAsyncCreated(GObject *source_object,
     } else if (data->isLive()) {
         QByteArray currentSourceId = data->currentSourceId();
         if (currentSourceId.isEmpty()) {
-            currentSourceId = data->parent()->defaultCollection(0).id().localId();
+            currentSourceId = data->parent()->defaultCollectionId().localId();
         }
         QList<QOrganizerItem> items = data->workingItems();
         QString managerUri = data->parent()->managerUri();
@@ -842,12 +842,9 @@ bool QOrganizerEDSEngine::removeItems(const QList<QOrganizerItemId> &itemIds,
     return (*error == QOrganizerManager::NoError);
 }
 
-QOrganizerCollection QOrganizerEDSEngine::defaultCollection(QOrganizerManager::Error* error)
+QOrganizerCollectionId QOrganizerEDSEngine::defaultCollectionId() const
 {
-    if (error) {
-        *error = QOrganizerManager::NoError;
-    }
-    return d->m_sourceRegistry->defaultCollection();
+    return d->m_sourceRegistry->defaultCollection().id();
 }
 
 QOrganizerCollection QOrganizerEDSEngine::collection(const QOrganizerCollectionId& collectionId,

--- a/organizer/qorganizer-eds-engine.h
+++ b/organizer/qorganizer-eds-engine.h
@@ -104,7 +104,7 @@ public:
                      QtOrganizer::QOrganizerManager::Error *error);
 
     // collections
-    QtOrganizer::QOrganizerCollection defaultCollection(QtOrganizer::QOrganizerManager::Error* error);
+    QtOrganizer::QOrganizerCollectionId defaultCollectionId() const override;
     QtOrganizer::QOrganizerCollection collection(const QtOrganizer::QOrganizerCollectionId &collectionId,
                                                   QtOrganizer::QOrganizerManager::Error *error);
     QList<QtOrganizer::QOrganizerCollection> collections(QtOrganizer::QOrganizerManager::Error* error);

--- a/tests/unittest/collections-test.cpp
+++ b/tests/unittest/collections-test.cpp
@@ -317,7 +317,7 @@ private Q_SLOTS:
         QTRY_COMPARE(createdCollection.count(), 1);
 
         // wait collection to became the default one
-        QTRY_COMPARE_WITH_TIMEOUT(m_engineRead->defaultCollection(0).id(), collection.id(), 5000);
+        QTRY_COMPARE_WITH_TIMEOUT(m_engineRead->defaultCollectionId(), collection.id(), 5000);
     }
 
     void testUpdateDefaultCollection()
@@ -325,7 +325,7 @@ private Q_SLOTS:
         static QString newCollectionId = uniqueCollectionName();
 
         // store current default collection
-        QOrganizerCollection defaultCollection = m_engineRead->defaultCollection(0);
+        QOrganizerCollectionId defaultCollectionId = m_engineRead->defaultCollectionId();
 
         // Create a collection
         QOrganizerCollection collection;
@@ -340,7 +340,7 @@ private Q_SLOTS:
         // make sure that the new collection is not default
         QOrganizerCollection newCollection = m_engineRead->collection(collection.id(), 0);
         QCOMPARE(newCollection.extendedMetaData(QStringLiteral("collection-default")).toBool(), false);
-        QVERIFY(newCollection.id() != defaultCollection.id());
+        QVERIFY(newCollection.id() != defaultCollectionId);
 
         // mark new collection as default
         QSignalSpy changedCollection(m_engineRead, SIGNAL(collectionsChanged(QList<QOrganizerCollectionId>)));
@@ -350,7 +350,7 @@ private Q_SLOTS:
         QTRY_COMPARE(changedCollection.count() , 3);
 
         // wait collection to became the default one
-        QTRY_COMPARE_WITH_TIMEOUT(m_engineRead->defaultCollection(0).id(), newCollection.id(), 5000);
+        QTRY_COMPARE_WITH_TIMEOUT(m_engineRead->defaultCollectionId(), newCollection.id(), 5000);
     }
 
     void testSaveCollectionWithAccountId()

--- a/tests/unittest/event-test.cpp
+++ b/tests/unittest/event-test.cpp
@@ -376,8 +376,8 @@ private Q_SLOTS:
         ids << items[0].id();
         items = m_engine->items(ids, hint, 0, 0);
         QCOMPARE(items.count(), 1);
-        QOrganizerCollection collection = m_engine->defaultCollection(0);
-        QCOMPARE(items[0].collectionId(), collection.id());
+        QOrganizerCollectionId collectionId = m_engine->defaultCollectionId();
+        QCOMPARE(items[0].collectionId(), collectionId);
     }
 
     void testCreateMultipleItemsWithSameCollection()

--- a/tests/unittest/filter-test.cpp
+++ b/tests/unittest/filter-test.cpp
@@ -110,7 +110,7 @@ private Q_SLOTS:
         QOrganizerItemCollectionFilter filter;
 
         // filter items from default collection
-        filter.setCollectionId(m_engine->defaultCollection(0).id());
+        filter.setCollectionId(m_engine->defaultCollectionId());
         items = m_engine->items(filter,
                       QDateTime(),
                       QDateTime(),
@@ -141,7 +141,7 @@ private Q_SLOTS:
 
         // filter items from both collections
         QSet<QOrganizerCollectionId> ids;
-        ids << m_engine->defaultCollection(0).id()
+        ids << m_engine->defaultCollectionId()
             << collection->id();
 
         filter.setCollectionIds(ids);

--- a/tests/unittest/parseecal-test.cpp
+++ b/tests/unittest/parseecal-test.cpp
@@ -389,7 +389,7 @@ private Q_SLOTS:
         QList<QOrganizerItemDetail::DetailType> detailsHint;
         GSList *events = g_slist_append(events, ical);
         QMap<QByteArray, GSList*> eventMap;
-        eventMap.insert(engine->defaultCollection(0).id().localId(), events);
+        eventMap.insert(engine->defaultCollectionId().localId(), events);
         engine->parseEventsAsync(eventMap, true, detailsHint, this, SLOT(onEventAsyncParsed(QList<QOrganizerItem>)));
 
         QTRY_COMPARE(m_itemsParsed.size(), 1);


### PR DESCRIPTION
Remove the unused defaultCollection() method; unfortunatley, due to the
missing "override" keyword we didn't notice that the parent class no
longer calls it.